### PR TITLE
Fix code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -13,7 +13,7 @@ export function openDesktop(url: string = '') {
   } else if (__WIN32__) {
     // https://github.com/nodejs/node/blob/b39dabefe6d/lib/child_process.js#L565-L577
     const shell = process.env.comspec || 'cmd.exe'
-    return ChildProcess.spawn(shell, ['/d', '/c', 'start', url], { env })
+    return ChildProcess.execFile(shell, ['/d', '/c', 'start', `"${url}"`], { env })
   } else if (__LINUX__) {
     return ChildProcess.spawn('xdg-open', [url], { env })
   } else {


### PR DESCRIPTION
Fixes [https://github.com/akadev1/desktop/security/code-scanning/1](https://github.com/akadev1/desktop/security/code-scanning/1)

To fix the problem, we should avoid passing the `url` directly to the shell command. Instead, we can use `ChildProcess.execFile` or `ChildProcess.spawn` with arguments to ensure that the `url` is treated as a single argument and not interpreted by the shell. This approach will prevent any special characters in the `url` from being misinterpreted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
